### PR TITLE
Added support for auto refresh of tokens.

### DIFF
--- a/AngularJSAuthentication.Web/app/services/authInterceptorService.js
+++ b/AngularJSAuthentication.Web/app/services/authInterceptorService.js
@@ -19,21 +19,14 @@ app.factory('authInterceptorService', ['$q', '$injector','$location', 'localStor
     var _responseError = function (rejection) {
         var deferred = $q.defer();
         if (rejection.status === 401) {
-            var authService = $injector.get('authService');
-            var authData = localStorageService.get('authorizationData');
-
-            if (authData && authData.useRefreshTokens) {
-                authService.refreshToken().then(function (response) {
-                    _retryHttpRequest(rejection.config, deferred);
-                }, function () {
-                    $location.path('/login');
-                    deferred.reject(rejection);
-                });
-            } else {
-                deferred.reject();
-            }
-            authService.logOut();
-            $location.path('/login');
+            authService.refreshToken().then(function (response) {
+                _retryHttpRequest(rejection.config, deferred);
+            }, function () {
+                var authService = $injector.get('authService');
+                authService.logOut();
+                $location.path('/login');
+                deferred.reject(rejection);
+            });
         } else {
             deferred.reject(rejection);
         }

--- a/AngularJSAuthentication.Web/app/services/authInterceptorService.js
+++ b/AngularJSAuthentication.Web/app/services/authInterceptorService.js
@@ -19,10 +19,10 @@ app.factory('authInterceptorService', ['$q', '$injector','$location', 'localStor
     var _responseError = function (rejection) {
         var deferred = $q.defer();
         if (rejection.status === 401) {
+            var authService = $injector.get('authService');
             authService.refreshToken().then(function (response) {
                 _retryHttpRequest(rejection.config, deferred);
             }, function () {
-                var authService = $injector.get('authService');
                 authService.logOut();
                 $location.path('/login');
                 deferred.reject(rejection);

--- a/AngularJSAuthentication.Web/app/services/authInterceptorService.js
+++ b/AngularJSAuthentication.Web/app/services/authInterceptorService.js
@@ -29,6 +29,8 @@ app.factory('authInterceptorService', ['$q', '$injector','$location', 'localStor
                     $location.path('/login');
                     deferred.reject(rejection);
                 });
+            } else {
+                deferred.reject();
             }
             authService.logOut();
             $location.path('/login');

--- a/AngularJSAuthentication.Web/app/services/authService.js
+++ b/AngularJSAuthentication.Web/app/services/authService.js
@@ -1,7 +1,8 @@
 ﻿'use strict';
-app.factory('authService', ['$http', '$q', 'localStorageService', 'ngAuthSettings', function ($http, $q, localStorageService, ngAuthSettings) {
+app.factory('authService', ['$q', '$injector', 'localStorageService', 'ngAuthSettings', function ($q, $injector, localStorageService, ngAuthSettings) {
 
     var serviceBase = ngAuthSettings.apiServiceBaseUri;
+    var $http;
     var authServiceFactory = {};
 
     var _authentication = {
@@ -14,6 +15,7 @@ app.factory('authService', ['$http', '$q', 'localStorageService', 'ngAuthSetting
 
         _logOut();
 
+        $http = $http || $injector.get('$http');
         return $http.post(serviceBase + 'api/account/register', registration).then(function (response) {
             return response;
         });
@@ -30,6 +32,7 @@ app.factory('authService', ['$http', '$q', 'localStorageService', 'ngAuthSetting
 
         var deferred = $q.defer();
 
+        $http = $http || $injector.get('$http');
         $http.post(serviceBase + 'token', data, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }).success(function (response) {
 
             if (loginData.useRefreshTokens) {
@@ -88,6 +91,7 @@ app.factory('authService', ['$http', '$q', 'localStorageService', 'ngAuthSetting
 
                 localStorageService.remove('authorizationData');
 
+                $http = $http || $injector.get('$http');
                 $http.post(serviceBase + 'token', data, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }).success(function (response) {
 
                     localStorageService.set('authorizationData', { token: response.access_token, userName: response.userName, refreshToken: response.refresh_token, useRefreshTokens: true });


### PR DESCRIPTION
In the comment section of [Enable OAuth Refresh Tokens in AngularJS... part 3](http://bitoftech.net/2014/07/16/enable-oauth-refresh-tokens-angularjs-app-using-asp-net-web-api-2-owin/), there was a wish to enable seamless refresh token requests. 

One way of doing this is to intercept the http response error and use the ideas in the [angular-http-auth library](https://github.com/witoldsz/angular-http-auth) to refresh the token and retry the original http request. 

This commit does the job. :-)

I've basically replaced the code that relocates to the refresh page in the response error interceptor, with a call to the refreshToken() method in the authService, and if this call is succesful, we retry the intercepted http request. 

The $http service is being injected by the $injector service instead of through the service constructor arguments, in order to avoid getting the cyclic dependency error. This is done both in the authInterceptorService and the authService.
